### PR TITLE
Add missing fields for RedistributionStateResponse

### DIFF
--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -701,10 +701,14 @@ components:
     RedistributionStateResponse:
       type: object
       properties:
+        hasSufficientFunds:
+          type: boolean
         isFrozen:
           type: boolean
         isFullySynced:
           type: boolean
+        phase:
+          type: string
         round:
           type: integer
         lastWonRound:


### PR DESCRIPTION
Added `phase` and `hasSufficientFunds`

### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
